### PR TITLE
Chainsecurity fixes

### DIFF
--- a/src/DSRAuthOracle.sol
+++ b/src/DSRAuthOracle.sol
@@ -12,6 +12,8 @@ import { IDSRAuthOracle }            from './interfaces/IDSRAuthOracle.sol';
  */
 contract DSRAuthOracle is AccessControl, DSROracleBase, IDSRAuthOracle {
 
+    uint256 private constant RAY = 1e27;
+
     bytes32 public constant DATA_PROVIDER_ROLE = keccak256('DATA_PROVIDER_ROLE');
 
     uint256 public maxDSR;
@@ -20,11 +22,11 @@ contract DSRAuthOracle is AccessControl, DSROracleBase, IDSRAuthOracle {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _setRoleAdmin(DATA_PROVIDER_ROLE, DEFAULT_ADMIN_ROLE);
 
-        maxDSR = 1e27;
+        maxDSR = RAY;
     }
 
     function setMaxDSR(uint256 _maxDSR) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_maxDSR >= 1e27, 'DSRAuthOracle/invalid-max-dsr');
+        require(_maxDSR >= RAY, 'DSRAuthOracle/invalid-max-dsr');
 
         maxDSR = _maxDSR;
         emit SetMaxDSR(_maxDSR);
@@ -51,14 +53,14 @@ contract DSRAuthOracle is AccessControl, DSROracleBase, IDSRAuthOracle {
 
         // DSR sanity bounds
         uint256 _maxDSR = maxDSR;
-        require(nextData.dsr >= 1e27,    'DSRAuthOracle/invalid-dsr');
+        require(nextData.dsr >= RAY,     'DSRAuthOracle/invalid-dsr');
         require(nextData.dsr <= _maxDSR, 'DSRAuthOracle/invalid-dsr');
 
         // `chi` must be non-decreasing
         require(nextData.chi >= previousData.chi, 'DSRAuthOracle/invalid-chi');
 
         // Accumulation cannot be larger than the time elapsed at the max dsr
-        uint256 chiMax = _rpow(_maxDSR, nextData.rho - previousData.rho) * previousData.chi / 1e27;
+        uint256 chiMax = _rpow(_maxDSR, nextData.rho - previousData.rho) * previousData.chi / RAY;
         require(nextData.chi <= chiMax, 'DSRAuthOracle/invalid-chi');
 
         _setPotData(nextData);

--- a/src/DSROracleBase.sol
+++ b/src/DSROracleBase.sol
@@ -51,7 +51,11 @@ abstract contract DSROracleBase is IDSROracle {
         if (timestamp == rho) return d.chi;
         require(timestamp >= rho, "DSROracleBase/invalid-timestamp");
 
-        return (timestamp > rho) ? _rpow(d.dsr, timestamp - rho) * uint256(d.chi) / RAY : d.chi;
+        uint256 duration;
+        unchecked {
+            duration = timestamp - rho;
+        }
+        return _rpow(d.dsr, duration) * uint256(d.chi) / RAY;
     }
 
     function getConversionRateBinomialApprox() external override view returns (uint256) {

--- a/src/forwarders/DSROracleForwarderBase.sol
+++ b/src/forwarders/DSROracleForwarderBase.sol
@@ -13,7 +13,7 @@ abstract contract DSROracleForwarderBase {
     IPot               public immutable pot;
     address            public immutable l2Oracle;
     
-    IDSROracle.PotData public _lastSeenPotData;
+    IDSROracle.PotData private _lastSeenPotData;
 
     constructor(address _pot, address _l2Oracle) {
         pot      = IPot(_pot);


### PR DESCRIPTION
Additionally there was a redundant ternary check in `getConversionRate`.