### PR TITLE
CS audit fixes

### DIFF
--- a/src/adapters/SSRChainlinkRateProviderAdapter.sol
+++ b/src/adapters/SSRChainlinkRateProviderAdapter.sol
@@ -16,8 +16,8 @@ contract SSRChainlinkRateProviderAdapter {
     }
 
     function latestAnswer() external view returns (int256) {
-        // Note: Cannot overflow due to division
-        return int256(ssrOracle.getConversionRate() / 1e19);
+        // Note: Assume no overflow
+        return int256(ssrOracle.getConversionRate());
     }
 
     function latestTimestamp() external view returns (uint256) {
@@ -25,7 +25,7 @@ contract SSRChainlinkRateProviderAdapter {
     }
 
     function decimals() external pure returns (uint8) {
-        return 8;
+        return 27;
     }
 
     function description() external pure returns (string memory) {
@@ -43,7 +43,8 @@ contract SSRChainlinkRateProviderAdapter {
     {
         return (
             0,
-            int256(ssrOracle.getConversionRate() / 1e19),
+            // Note: Assume no overflow
+            int256(ssrOracle.getConversionRate()),
             0,
             block.timestamp,
             0

--- a/test/SSRChainlinkRateProviderAdapter.sol
+++ b/test/SSRChainlinkRateProviderAdapter.sol
@@ -41,15 +41,15 @@ contract SSRChainlinkRateProviderAdapterTest is Test {
     }
 
     function test_hardcodedValues() public {
-        assertEq(adapter.decimals(),    8);
+        assertEq(adapter.decimals(),    27);
         assertEq(adapter.description(), "sUSDS / USDS");
         assertEq(adapter.version(),     1);
     }
 
     function test_conversion() public {
-        _assertData(1e8);
+        _assertData(1e27);
         oracle.setConversionRate(1.2e27);
-        _assertData(1.2e8);
+        _assertData(1.2e27);
     }
 
     function _assertData(int256 value) internal {

--- a/test/SSROracleXChainIntegrationBase.t.sol
+++ b/test/SSROracleXChainIntegrationBase.t.sol
@@ -111,9 +111,9 @@ abstract contract SSROracleXChainIntegrationBaseTest is Test {
         assertEq(balancerAdapter.getRate(), 1e18);
         assertApproxEqAbs(balancerAdapter.getRate(), susdsConversionRate, 1e10);
 
-        assertEq(chainlinkAdapter.latestAnswer(), 1e8);
+        assertEq(chainlinkAdapter.latestAnswer(), 1e27);
         (, int256 answer,,,) = chainlinkAdapter.latestRoundData();
-        assertEq(answer, 1e8);
+        assertEq(answer, 1e27);
     }
 
 }


### PR DESCRIPTION
Removing the division to 8 decimals. Most Chainlink oracles use 8 decimals, but there is no need to do this division if we don't have to.